### PR TITLE
Bug 534564 - Use only necessary classes for barebone theme

### DIFF
--- a/less/solstice/_barebone/core.less
+++ b/less/solstice/_barebone/core.less
@@ -107,7 +107,8 @@
 @import "~bootstrap/less/utilities.less";
 @import "~bootstrap/less/responsive-utilities.less";
 @import "~bootstrap/less/responsive-utilities.less";
-@import "../../_components/classes.less";
+@import "../../_components/classes-padding-margin.less";
+//@import "../../_components/classes.less";
 @import "~Yamm/yamm/yamm.less";
 @import "../_default/header.less";
 


### PR DESCRIPTION
Change-Id: I00e7a29559265efa2ea2b1ddcf2b1210d771a7cf
Signed-off-by: Eric Poirier <eric.poirier@eclipse-foundation.org>