### PR TITLE
Bug 546088] Include Java Compatible, Enterprise Edition logo with

### DIFF
--- a/less/quicksilver/packages/components/downloads.less
+++ b/less/quicksilver/packages/components/downloads.less
@@ -88,7 +88,7 @@
 }
 
 .downloads-logo{
-  width:100px;
+  width:160px;
   height:50px;
   margin:0 auto 15px;
   display:flex;

--- a/less/quicksilver/packages/components/mirror.less
+++ b/less/quicksilver/packages/components/mirror.less
@@ -40,7 +40,11 @@
 }
 
 .mirror-members-h2{
+  /*
+  We need to migrate downloads.git to webpack to allow us to do this
   background-image:url(../../../images/eclipse_org/downloads/mirror-h2-bg.jpg);
+  */
+  background-image:url(../images/mirror-h2-bg.jpg);
   background-size:cover;
   color:#fff;
   padding:20px;


### PR DESCRIPTION
Glashfish logo on download page

Signed-off-by: Christopher Guindon <chris.guindon@eclipse-foundation.org>