### PR TITLE
Infra 3249 - Published 2019 Annual Eclipse Foundation Community Report

### DIFF
--- a/less/_components/classes-lists.less
+++ b/less/_components/classes-lists.less
@@ -122,6 +122,11 @@ ul.circles-list {
   }
 }
 
+ul.list-no-bullets {
+    list-style-type: none;
+}
+
+
 // fa-lists
 .fa-ul-2x{
   margin-left:3.14286em;


### PR DESCRIPTION
Updated list styles to include list-no-bullets class to remove list styling
while maintaining left padding.

Change-Id: Ife463c557be8eeb349bcda08f1c61812e838f803
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>