### PR TITLE
Featured story block shows background image on ultrawide displays #79

### DIFF
--- a/less/_components/quicksilver/featured-story.less
+++ b/less/_components/quicksilver/featured-story.less
@@ -95,9 +95,10 @@
       .clip-path-shape(@featured-story-ad-shape);
     }
     &:after {
-      width: 1000px;
+      width: 50vw;
       z-index: 1;
       left: 0;
+      overflow-x: hidden;
     }
   }
   a{


### PR DESCRIPTION
Fixed view width, tested at >4000px display. Incremented version.

Change-Id: I0986c1d9484cee3ab1d404a0a07c17c2d74cfb32
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>