### PR TITLE
Fix jquery version to use 3.5.1 (latest)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4987,9 +4987,9 @@
       }
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "jquery-eclipsefdn-api": {
       "version": "0.0.32",
@@ -4998,6 +4998,13 @@
       "requires": {
         "jquery": "3.3.1",
         "mustache": "^4.0.1"
+      },
+      "dependencies": {
+        "jquery": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+          "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+        }
       }
     },
     "jquery-match-height": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cookieconsent": "^3.1.0",
     "feather-icons": "^4.7.0",
     "font-awesome": "^4.7.0",
-    "jquery": "3.3.1",
+    "jquery": "^3.5.1",
     "jquery-eclipsefdn-api": "0.0.32",
     "jquery-match-height": "^0.7.2",
     "laravel-mix": "4.0.14",


### PR DESCRIPTION
Regression that necessitated a downgrade has been fixed in the patch
mentioned in a jquery blog post.
https://blog.jquery.com/2020/05/04/jquery-3-5-1-released-fixing-a-regression/

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>