### PR TITLE
Update content nav tab clicks for content-nav-tab-all-all

### DIFF
--- a/js/solstice.js
+++ b/js/solstice.js
@@ -180,7 +180,6 @@
   $("a.alt-tab-toggle").click(function(e) {
     // get current element that triggered update
     var $t = $(e.target);
-    console.log($t)
     // trigger click event on tab to properly transition
     var $tabControl = $("ul.nav.nav-tabs [aria-controls=\""+$t.attr("href").substring(1)+"\"]");
     $tabControl.trigger("click");
@@ -194,6 +193,19 @@
     }
   });
 
+  // on tab navigation click
+  $("li[role=\"presentation\"] a").click(function() {
+    var $t = $(this);
+    if ($t.data("content-target") !== undefined) {
+      if ($t.attr("id") === "showalltabs" && !$($t.data("content-target")).hasClass("content-nav-tab-all")) {
+        $($t.data("content-target")).addClass("content-nav-tab-all");
+      } else if($t.attr("id") !== "showalltabs"){
+        $($t.data("content-target")).removeClass("content-nav-tab-all");
+      }
+    }
+    return true;
+  });
+  
   // Infra 2791 - Send events to Google Analytics
   $('a[href]').click(function() {
     if (typeof ga === "function") {

--- a/less/_components/quicksilver/content-nav-tab.less
+++ b/less/_components/quicksilver/content-nav-tab.less
@@ -30,7 +30,12 @@
   padding-right: 0;
   margin: 0;
 }
-
+.content-nav-tab-all .content-nav-tab-all-show {
+  display: block;
+}
+.content-nav-tab-all .content-nav-tab-all-hide {
+  display: none;
+}
 .content-nav-tab li.active a,.content-nav-tab li.active a:focus,.content-nav-tab li.active a:hover {
   background-color: @content-nav-tab-active-tab-bg-color;
 }


### PR DESCRIPTION
On click of showalltabs tab or alt tab target, class of
content-nav-tab-all will be added to the content-target element.
Otherwise it is removed on tab clicks.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>