### PR TITLE
Infra 3856 - Membership page is misaligned on mobile

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -421,7 +421,7 @@
             </ul>
           </div>
         </div>
-        <div class="content-nav-tab-body tab-content padding-40" id="tabs-content">
+        <div class="content-nav-tab-body tab-content" id="tabs-content">
           <div role="tabpanel" class="tab-pane tab-pane active" id="tab-one">
             <h2 class="h3 margin-top-0">One</h2>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -481,7 +481,7 @@
     &lt;/ul&gt;
   &lt;/div&gt;
 &lt;/div&gt;
-&lt;div class="content-nav-tab-body tab-content padding-40" id="tabs-content"&gt;
+&lt;div class="content-nav-tab-body tab-content" id="tabs-content"&gt;
   &lt;div role="tabpanel" class="tab-pane tab-pane active" id="tab-one"&gt;
     &lt;h2 class="h3 margin-top-0"&gt;One&lt;/h2&gt;
     &lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.&lt;/p&gt;

--- a/less/_components/quicksilver/content-nav-tab.less
+++ b/less/_components/quicksilver/content-nav-tab.less
@@ -43,6 +43,10 @@
   .content-nav-tab-toggle {
     margin-top: 20px;
   }
+  .content-nav-tab-body{
+    padding-left: 40px;
+    padding-right: 40px;
+  }
 }
 
 // Works with bootstrap nav-tabs, so we override mobile view and leave other bps alone


### PR DESCRIPTION
Added padding on small screens and up for content nav tabs, and removed
the padding-40 class on the example HTML.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>