### PR TITLE
add reusable styles for membership page and can also use in other sites

### DIFF
--- a/less/_components/buttons.less
+++ b/less/_components/buttons.less
@@ -40,3 +40,7 @@
 .share-button-mail {
   background-color:#949494
 }
+
+.fit-content {
+  width: fit-content;
+}

--- a/less/_components/classes-grid.less
+++ b/less/_components/classes-grid.less
@@ -129,4 +129,9 @@
   .justify-left-mobile {
     justify-content: left;
   }
+
+  .no-gutters-mobile {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }


### PR DESCRIPTION
This is also part of https://bugs.eclipse.org/bugs/show_bug.cgi?id=567547

- added "no-gutters-mobile" to remove padding left and padding right on mobile view
- added "fit-content" for button "contact us about membership"

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>