### PR TITLE
need important and no need for fit-content

### DIFF
--- a/less/_components/buttons.less
+++ b/less/_components/buttons.less
@@ -40,7 +40,3 @@
 .share-button-mail {
   background-color:#949494
 }
-
-.fit-content {
-  width: fit-content;
-}

--- a/less/_components/classes-grid.less
+++ b/less/_components/classes-grid.less
@@ -129,9 +129,4 @@
   .justify-left-mobile {
     justify-content: left;
   }
-
-  .no-gutters-mobile {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-  }
 }

--- a/less/_components/classes-grid.less
+++ b/less/_components/classes-grid.less
@@ -131,7 +131,7 @@
   }
 
   .no-gutters-mobile {
-    padding-left: 0;
-    padding-right: 0;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
   }
 }

--- a/less/_components/quicksilver/content-nav-tab.less
+++ b/less/_components/quicksilver/content-nav-tab.less
@@ -105,4 +105,9 @@
   .content-nav-tab-body.tab-content {
     border: none;
   }
+
+  .content-nav-tab-body.no-gutters-mobile {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }


### PR DESCRIPTION
Do need "!important" for no-gutters-mobile, otherwise it will be overridden by paddings classes, and I removed fit-content since no need for it if the paddings are removed. 

I find I can remove the "padding-right-40" and "padding-left-40" since the class ".content-nav-tab-body." and "tab-content" gives a padding 40 on big screen and a padding 10 on mobile view.

@chrisguindon  I wonder if you like to keep the 10 paddings on the mobile view?  - If so, we do not need to add any new classes as long as the screen is bigger than 360px. 
The following are the view with 10 paddings: ( You can see, with 10 paddings and without fit-content, the button would be a little bit ugly on size 360px. )
![image](https://user-images.githubusercontent.com/39588094/95241586-f84d9b80-07db-11eb-91ed-dd59436c9945.png)
![image](https://user-images.githubusercontent.com/39588094/95241535-e2d87180-07db-11eb-8ad8-fae82d5e6080.png)

this following is a wider mobile with 375px: ( You can see, with 10 paddings and without fit-content, the button is good on size 375px. )
![image](https://user-images.githubusercontent.com/39588094/95241638-0a2f3e80-07dc-11eb-94ff-5a9019e9d8f7.png)


If you prefer to use 0 paddings, then we probably need this no-gutters-mobile class.

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>