### PR TITLE
add class for hugo footer

### DIFF
--- a/less/_components/footer.less
+++ b/less/_components/footer.less
@@ -15,7 +15,7 @@
 // Solstice default footer styles
 // author: Christopher Guindon <chris.guindon@eclipse-foundation.org>
 
-footer#solstice-footer {
+footer#solstice-footer, footer.solstice-footer {
   background: @footer-background;
   font-family: @font-family-base;
   padding-top: @footer-padding-top;


### PR DESCRIPTION
To be able to add params to custom footer instead of {{ define footer }} for https://github.com/jakartaee/jakarta.ee/pull/929

It's a combine with https://github.com/EclipseFdn/hugo-solstice-theme/pull/179

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>