### PR TITLE
fix events registeration link spacing on mobile view

### DIFF
--- a/less/_components/events/eclipsefdn-registration.less
+++ b/less/_components/events/eclipsefdn-registration.less
@@ -18,6 +18,9 @@
   p{
     margin-bottom:20px;
   }
+  li {
+    margin-bottom: 5px;
+  }
 }
 
 .eclipsefdn-registration-links:only-child { 


### PR DESCRIPTION
To fix:

![image](https://user-images.githubusercontent.com/39588094/98587138-bbbc0680-2297-11eb-89a0-df9b0b6d73dd.png)


Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>