### PR TITLE
fix events registeration link spacing on mobile view

### DIFF
--- a/less/_components/events/eclipsefdn-registration.less
+++ b/less/_components/events/eclipsefdn-registration.less
@@ -18,9 +18,10 @@
   p{
     margin-bottom:20px;
   }
-  .eclipsefdn-registration-links li {
-    margin-bottom: 5px;
-  }
+}
+
+.eclipsefdn-registration-links li {
+  margin-bottom: 5px;
 }
 
 .eclipsefdn-registration-links:only-child { 

--- a/less/_components/events/eclipsefdn-registration.less
+++ b/less/_components/events/eclipsefdn-registration.less
@@ -18,6 +18,9 @@
   p{
     margin-bottom:20px;
   }
+  .eclipsefdn-registration-links li {
+    margin-bottom: 5px;
+  }
 }
 
 .eclipsefdn-registration-links:only-child { 


### PR DESCRIPTION
to fix:

![image](https://user-images.githubusercontent.com/39588094/98587435-23725180-2298-11eb-8b06-df7ef93edb0b.png)


Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>