### PR TITLE
Bug 561500 - Prevent errors if ga.getAll is not a function

### DIFF
--- a/js/solstice.js
+++ b/js/solstice.js
@@ -220,7 +220,7 @@
   
   // Infra 2791 - Send events to Google Analytics
   $('a[href]').click(function() {
-    if (typeof ga === "function") {
+    if (typeof ga === "function" && typeof ga.getAll  === "function") {
       // Get the file name out of the href attribute
       var fileName = $(this).attr('href').split('/').pop();
 


### PR DESCRIPTION
Change-Id: I930e49fde30ad6bb32b994b0a7c9bd51dd1eb756
Signed-off-by: Eric Poirier <eric.poirier@eclipse-foundation.org>