### PR TITLE
Updated img width to 100%

### DIFF
--- a/less/_components/bootstrap/panels.less
+++ b/less/_components/bootstrap/panels.less
@@ -43,6 +43,7 @@
   }
   .img {
     border-radius: 1em;
+    width: 100%;
   }
   .panel-body {
       padding: 15px 15px 0 15px;


### PR DESCRIPTION
This will make sure the image will always occupy the full width of the image container.
Related to bug-4190 on Gerrit